### PR TITLE
Cloud sync rest api

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,5 +1,5 @@
 import { MapeoCloud } from "./index.js";
 
-const config = await MapeoCloud.getConfig("./.env")
+const config = await MapeoCloud.getConfig("./example.env")
 const mapeoCloud = new MapeoCloud(config)
 await mapeoCloud.start()

--- a/index.js
+++ b/index.js
@@ -27,14 +27,18 @@ export class MapeoCloud {
         return validate({ dotenvFilepath, schema })
     }
 
-    handle(conn, req) {
+    /**
+     * @type {import('@fastify/websocket').WebsocketHandler}
+     */
+    sync(conn, _) {
       conn.pipe(conn)
-      // conn.socket.on('message', console.log)
+      // conn.pipe(this.mapeo.getReplicationStream()).pipe(conn)
+      conn.socket.on('message', console.log)
     }
 
 
     async start () {
         await this.mapeo.ready()
-        await api.start(this.handle)
+        await api.start(this.sync)
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
+// @ts-check
 import * as path from 'path'
 import * as fs from 'fs/promises'
 
 import Corestore from 'corestore'
 import Sqlite from 'better-sqlite3'
 import { Mapeo } from '@mapeo/core'
+import * as api from './lib/api.js'
 
 import { schema, validate } from './lib/config.js'
 
@@ -25,7 +27,14 @@ export class MapeoCloud {
         return validate({ dotenvFilepath, schema })
     }
 
+    handle(conn, req) {
+      conn.pipe(conn)
+      // conn.socket.on('message', console.log)
+    }
+
+
     async start () {
         await this.mapeo.ready()
+        await api.start(this.handle)
     }
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import * as path from 'path'
 import * as fs from 'fs/promises'
 
 import Corestore from 'corestore'
+import SecretStream from '@hyperswarm/secret-stream'
 import Sqlite from 'better-sqlite3'
 import { Mapeo } from '@mapeo/core'
 import * as api from './lib/api.js'
@@ -30,10 +31,10 @@ export class MapeoCloud {
     /**
      * @type {import('@fastify/websocket').WebsocketHandler}
      */
-    sync(conn, _) {
-      conn.pipe(conn)
-      // conn.pipe(this.mapeo.getReplicationStream()).pipe(conn)
-      conn.socket.on('message', console.log)
+    sync(wss, _) {
+      const noiseStream = new SecretStream()
+      noiseStream.pipe(wss).pipe(noiseStream)
+      // this.mapeo.coreManager.replicate(noiseStream)
     }
 
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -14,7 +14,7 @@ const defaultHandler = (conn,_) => {
 /**
  * @param {import('@fastify/websocket').WebsocketHandler} handler
  */
-const setup = (handler) => {
+const setup = (handler = defaultHandler) => {
   f.register(ws)
   f.register(async (fastify) => {
     fastify.route({
@@ -28,7 +28,7 @@ const setup = (handler) => {
           })
           .send('ok')
       },
-      wsHandler: handler || defaultHandler
+      wsHandler: handler
     })
   })
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,15 +4,22 @@ import ws from '@fastify/websocket'
 
 const f = fastify({logger:true})
 
+/**
+ * @type {import('@fastify/websocket').WebsocketHandler}
+ */
 const defaultHandler = (conn,_) => {
   conn.pipe(conn)
 }
-const setup = (handle) => {
+
+/**
+ * @param {import('@fastify/websocket').WebsocketHandler} handler
+ */
+const setup = (handler) => {
   f.register(ws)
   f.register(async (fastify) => {
     fastify.route({
       method:'GET',
-      url: '/',
+      url: '/sync',
       handler: (_,reply) => {
         reply.code(101)
           .headers({
@@ -21,12 +28,16 @@ const setup = (handle) => {
           })
           .send('ok')
       },
-      wsHandler: handle || defaultHandler
+      wsHandler: handler || defaultHandler
     })
   })
 }
-export const start = async (handle) => {
-  setup(handle)
+
+/**
+ * @param {import('@fastify/websocket').WebsocketHandler} handler
+ */
+export const start = async (handler) => {
+  setup(handler)
   try{
     await f.listen({port: 3000})
   }catch(e){

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,36 @@
+// @ts-check
+import fastify from 'fastify'
+import ws from '@fastify/websocket'
+
+const f = fastify({logger:true})
+
+const defaultHandler = (conn,_) => {
+  conn.pipe(conn)
+}
+const setup = (handle) => {
+  f.register(ws)
+  f.register(async (fastify) => {
+    fastify.route({
+      method:'GET',
+      url: '/',
+      handler: (_,reply) => {
+        reply.code(101)
+          .headers({
+            'Upgrade': 'websocket',
+            'Connection': 'Upgrade'
+          })
+          .send('ok')
+      },
+      wsHandler: handle || defaultHandler
+    })
+  })
+}
+export const start = async (handle) => {
+  setup(handle)
+  try{
+    await f.listen({port: 3000})
+  }catch(e){
+    f.log.error(e)
+    process.exit(1)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
 	},
 	"homepage": "https://github.com/digidem/mapeo-cloud#readme",
 	"dependencies": {
-		"@mapeo/core": "github:digidem/mapeo-core-next#authstore",
+		"@fastify/websocket": "^8.1.0",
+		"@mapeo/core": "github:digidem/mapeo-core-next",
 		"better-sqlite3": "^8.0.1",
 		"corestore": "^6.4.0",
 		"desm": "^1.3.0",
-		"env-schema": "^5.2.0"
+		"env-schema": "^5.2.0",
+		"fastify": "^4.17.0"
 	},
 	"devDependencies": {
 		"brittle": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 	"homepage": "https://github.com/digidem/mapeo-cloud#readme",
 	"dependencies": {
 		"@fastify/websocket": "^8.1.0",
+		"@hyperswarm/secret-stream": "^6.1.2",
 		"@mapeo/core": "github:digidem/mapeo-core-next",
 		"better-sqlite3": "^8.0.1",
 		"corestore": "^6.4.0",


### PR DESCRIPTION
The idea for this PR would be to:
* Implement an endpoint `/sync` that returns a websocket connection through updating an https connection. This socket would basically sync cores pertaining one project. There's no need to create endpoints for different projects since the idea is to have one machine per project and the routing would be handled by the gateway server (which should live in another repo)

Is there any other endpoints that we would need to create?
Probably if there's the need to create a web UI, we would need other http endpoints besides websocket for sync...


This would close #2
